### PR TITLE
WIP - Fix bugs

### DIFF
--- a/src/SilbinaryWolf/Components/ComponentData.php
+++ b/src/SilbinaryWolf/Components/ComponentData.php
@@ -17,6 +17,15 @@ class ComponentData extends ViewableData
     protected $____name;
 
     /**
+     * Various ViewableData properties such as:
+     * - $class
+     * - $failover
+     *
+     * @var \stdClass
+     */
+    protected $____viewabledata;
+
+    /**
      * NOTE(Jake): 2018-04-06
      *
      * We use a custom class instead of ArrayData to avoid
@@ -28,9 +37,28 @@ class ComponentData extends ViewableData
     public function __construct($name, array $props)
     {
         parent::__construct();
+
+        // NOTE(Jake): 2018-06-01
+        //
+        // Move underlying properties to `____viewabledata`
+        // We do this to avoid clashing of property names like $class.
+        //
+        // ie. If you don't pass a $class variable in, $class will end
+        //     up defaulting to 'SilbinaryWolf\Components\ComponentData'.
+        //
+        //     We don't want this!
+        //
+        $data = new \stdClass;
+        foreach (get_object_vars($this) as $prop => $value) {
+            $data->{$prop} = $value;
+            unset($this->{$prop});
+        }
+        $this->____viewabledata = $data;
+
+        //
         $this->____name = $name;
-        foreach ($props as $name => $value) {
-            $this->{$name} = $value;
+        foreach ($props as $prop => $value) {
+            $this->{$prop} = $value;
         }
     }
 

--- a/src/SilbinaryWolf/Components/ComponentService.php
+++ b/src/SilbinaryWolf/Components/ComponentService.php
@@ -13,6 +13,7 @@ use Debug;
 use SS_List;
 use DataObject;
 use StringField;
+use Text;
 
 class ComponentService
 {
@@ -144,6 +145,9 @@ PHP;
         if (count($parts) === 1) {
             if (!($parts[0] instanceof StringField)) {
                 return $parts[0];
+            }
+            if (($parts[0] instanceof Text)) {
+                return $parts[0]->RAW();
             }
         }
         return Injector::inst()->createWithArgs('SilbinaryWolf\Components\DBComponentField', array($name, $parts));

--- a/src/SilbinaryWolf/Components/DBComponentField.php
+++ b/src/SilbinaryWolf/Components/DBComponentField.php
@@ -18,7 +18,12 @@ class DBComponentField extends Text
      * @var array
      */
     private static $text_property_casting = array(
-        'getAttributesHTML' => true,
+        // NOTE(Jake): 2018-06-01
+        //
+        // No longer needed due to the fix that uses:
+        // - if (($parts[0] instanceof Text)) { return $parts[0]->RAW();}
+        //
+        //'getAttributesHTML' => true,
     );
 
     /**


### PR DESCRIPTION
This is an attempt at fixing:
https://github.com/silbinarywolf/silverstripe-components/issues/14
https://github.com/silbinarywolf/silverstripe-components/issues/15
https://github.com/silbinarywolf/silverstripe-components/issues/16

Remaining work:
- Create test where we render a component that has the variable $class,  this should render a blank string if nothing is passed in. (This will prove that we aren't inheritting ViewableData props)
- `($parts[0] instanceof Text)` might need to also include an `|| is_string($parts[0])` logic for `getAttributesHTML()` If that doesn't work, I'll need to reinstate the getAttributesHTML `text_property_casting` logic. 