### PR TITLE
new(ComponentService) Configure component template source

### DIFF
--- a/docs/en/quick-start.md
+++ b/docs/en/quick-start.md
@@ -27,3 +27,23 @@
 	</span>
 </:MyComponentButton>
 ```
+
+## Configuration
+
+Components are looked up from the {theme_dir}/templates/components path by
+default. If you wish to further separate this location, you must let the
+`ComponentService` know what these sub-paths are by setting the 
+`component_paths` configuration option, for example
+
+```
+
+---
+Name: component_overrides
+---
+SilbinaryWolf\Components\ComponentService:
+  component_paths:
+    - components/atoms
+    - components/molecules
+    - components/organisms
+
+```

--- a/src/SilbinaryWolf/Components/ComponentService.php
+++ b/src/SilbinaryWolf/Components/ComponentService.php
@@ -162,7 +162,7 @@ PHP;
      * @param  SSViewer_Scope $scope
      * @return DBHTMLText
      */
-    public function renderComponent($name, array $props, SSViewer_Scope $scope = null)
+    public function renderComponent($name, array $props, SSViewer_Scope $scope)
     {
         $templates = [];
         foreach ($this->componentTemplatePaths as $path) {

--- a/src/SilbinaryWolf/Components/ComponentService.php
+++ b/src/SilbinaryWolf/Components/ComponentService.php
@@ -15,6 +15,10 @@ use SilverStripe\ORM\FieldType\DBString;
 
 class ComponentService
 {
+    public $componentTemplatePaths = [
+        'components'
+    ];
+
     /**
      * @param array            $res
      * @param SSTemplateParser $parser
@@ -158,13 +162,18 @@ PHP;
      * @param  SSViewer_Scope $scope
      * @return DBHTMLText
      */
-    public function renderComponent($name, array $props, SSViewer_Scope $scope)
+    public function renderComponent($name, array $props, SSViewer_Scope $scope = null)
     {
-        $templates = [
-            ["type" => "components", $name],
-            ["type" => "Includes", $name],
-            $name
-        ];
+        $templates = [];
+        foreach ($this->componentTemplatePaths as $path) {
+            $templates[] = ['type' => $path, $name];
+        }
+
+        // hardcoded default locations that need to come after the configurable
+        // ones defined above
+        $templates[] = ["type" => "Includes", $name];
+        $templates[] = $name;
+
         $result = Injector::inst()->createWithArgs(SSViewer::class, [$templates]);
         $data = new ComponentData($name, $props);
         $result = $result->process($data);

--- a/src/SilbinaryWolf/Components/ComponentService.php
+++ b/src/SilbinaryWolf/Components/ComponentService.php
@@ -12,10 +12,11 @@ use SilverStripe\View\ArrayData;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBString;
+use SilverStripe\Core\Config\Config;
 
 class ComponentService
 {
-    public $componentTemplatePaths = [
+    private static $component_paths = [
         'components'
     ];
 
@@ -165,7 +166,7 @@ PHP;
     public function renderComponent($name, array $props, SSViewer_Scope $scope)
     {
         $templates = [];
-        foreach ($this->componentTemplatePaths as $path) {
+        foreach (Config::inst()->get(__CLASS__, 'component_paths') as $path) {
             $templates[] = ['type' => $path, $name];
         }
 

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -12,6 +12,7 @@ use SilverStripe\Forms\TextField;
 use SilverStripe\View\ViewableData;
 use SilbinaryWolf\Components\ComponentService;
 use SilverStripe\View\SSViewer_Scope;
+use SilverStripe\Core\Injector\Injector;
 
 class ComponentTest extends SapphireTest
 {
@@ -29,10 +30,11 @@ class ComponentTest extends SapphireTest
 
     public function testCustomizedComponentPath()
     {
-        $service = new ComponentService();
-        $service->componentTemplatePaths = [
+        Config::inst()->update(ComponentService::class, 'component_paths', [
             'components/subfolder'
-        ];
+        ]);
+
+        $service = Injector::inst()->get(ComponentService::class);
 
         $scope = new SSViewer_Scope(null);
         try {

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -10,8 +10,8 @@ use SilverStripe\ORM\ArrayList;
 use SilverStripe\View\ArrayData;
 use SilverStripe\Forms\TextField;
 use SilverStripe\View\ViewableData;
-use SilverStripe\Core\Injector\Injector;
 use SilbinaryWolf\Components\ComponentService;
+use SilverStripe\View\SSViewer_Scope;
 
 class ComponentTest extends SapphireTest
 {
@@ -27,15 +27,16 @@ class ComponentTest extends SapphireTest
         parent::tearDown();
     }
 
-    public function testComponentLookup()
+    public function testCustomizedComponentPath()
     {
         $service = new ComponentService();
         $service->componentTemplatePaths = [
             'components/subfolder'
         ];
 
+        $scope = new SSViewer_Scope(null);
         try {
-            $resultHTML = $service->renderComponent('SubComponent', []);
+            $resultHTML = $service->renderComponent('SubComponent', [], $scope);
         } catch (\Exception $e) {
             $this->assertTrue(strpos($e->getMessage(), "None of the following templates could be found") !== false);
         }
@@ -44,7 +45,7 @@ class ComponentTest extends SapphireTest
             'components/subfolder'
         ];
 
-        $resultHTML = $service->renderComponent('SubComponent', [], null);
+        $resultHTML = $service->renderComponent('SubComponent', [], $scope);
 
         $expected = '<button class="subcomponent">Text</button>';
         $this->assertEquals($expected, trim($resultHTML->getValue()));

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -10,6 +10,8 @@ use SilverStripe\ORM\ArrayList;
 use SilverStripe\View\ArrayData;
 use SilverStripe\Forms\TextField;
 use SilverStripe\View\ViewableData;
+use SilverStripe\Core\Injector\Injector;
+use SilbinaryWolf\Components\ComponentService;
 
 class ComponentTest extends SapphireTest
 {
@@ -23,6 +25,30 @@ class ComponentTest extends SapphireTest
     public function tearDown()
     {
         parent::tearDown();
+    }
+
+    public function testComponentLookup()
+    {
+        $service = new ComponentService();
+        $service->componentTemplatePaths = [
+            'components/subfolder'
+        ];
+
+        try {
+
+            $resultHTML = $service->renderComponent('SubComponent', []);
+        } catch (\Exception $e) {
+            $this->assertTrue(strpos($e->getMessage(), "None of the following templates could be found") !== false);
+        }
+
+        $service->componentTemplatePaths = [
+            'components/subfolder'
+        ];
+
+        $resultHTML = $service->renderComponent('SubComponent', [], null);
+
+        $expected = '<button class="subcomponent">Text</button>';
+        $this->assertEquals($expected, trim($resultHTML->getValue()));
     }
 
     /**
@@ -192,7 +218,7 @@ HTML;
         $resultHTML = SSViewer::fromString($template)->process(
             new ArrayData(
                 array(
-                'Field' => $formField,
+                    'Field' => $formField,
                 )
             )
         );
@@ -232,7 +258,7 @@ HTML;
         $resultHTML = SSViewer::fromString($template)->process(
             new ArrayData(
                 array(
-                'MenuList' => $list,
+                    'MenuList' => $list,
                 )
             )
         );
@@ -279,10 +305,10 @@ HTML;
         $resultHTML = SSViewer::fromString($template)->process(
             new ArrayData(
                 array(
-                'MyRecord' => $record,
-                'MyArrayData' => new ArrayData(array(
-                    'Title' => 'ArrayData Title 2'
-                ))
+                    'MyRecord' => $record,
+                    'MyArrayData' => new ArrayData(array(
+                        'Title' => 'ArrayData Title 2'
+                    ))
                 )
             )
         );
@@ -320,7 +346,7 @@ HTML;
         $resultHTML = SSViewer::fromString($template)->process(
             new ArrayData(
                 array(
-                'Field' => $formField,
+                    'Field' => $formField,
                 )
             )
         );

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -30,7 +30,7 @@ class ComponentTest extends SapphireTest
 
     public function testCustomizedComponentPath()
     {
-        Config::inst()->update(ComponentService::class, 'component_paths', [
+        Config::modify()->set(ComponentService::class, 'component_paths', [
             'components/subfolder'
         ]);
 

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -35,7 +35,6 @@ class ComponentTest extends SapphireTest
         ];
 
         try {
-
             $resultHTML = $service->renderComponent('SubComponent', []);
         } catch (\Exception $e) {
             $this->assertTrue(strpos($e->getMessage(), "None of the following templates could be found") !== false);

--- a/tests/templates/components/subfolder/SubComponent.ss
+++ b/tests/templates/components/subfolder/SubComponent.ss
@@ -1,0 +1,1 @@
+<button class="subcomponent">Text</button>


### PR DESCRIPTION
Provides a mechanism to customise the paths looked in to load
component templates from

* Added new configurable property **ComponentService::componentTemplatePaths**
* Made the "scope" parameter optional - it's near on impossible to mock reasonably
* Added test for the above

To configure the template paths, in your project's .yml file

```
---
Name: component_overrides
---
SilverStripe\Core\Injector\Injector:
  SilbinaryWolf\Components\ComponentService:
    properties:
      componentTemplatePaths:
        - components
        - components/atoms
        - components/molecules
        - components/organisms
```