### PR TITLE
fix(ComponentService): Fix bug where $Message from a FormField would be double escaped and print &quot - Github #16

### DIFF
--- a/src/SilbinaryWolf/Components/ComponentService.php
+++ b/src/SilbinaryWolf/Components/ComponentService.php
@@ -5,6 +5,7 @@ namespace SilbinaryWolf\Components;
 use SSViewer;
 use SSViewer_Scope;
 use HTMLText;
+use Text;
 use Injector;
 use SSTemplateParser;
 use SSTemplateParseException;
@@ -144,6 +145,9 @@ PHP;
         if (count($parts) === 1) {
             if (!($parts[0] instanceof StringField)) {
                 return $parts[0];
+            }
+            if (($parts[0] instanceof Text)) {
+                return $parts[0]->RAW();
             }
         }
         return Injector::inst()->createWithArgs('SilbinaryWolf\Components\DBComponentField', array($name, $parts));

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -384,6 +384,35 @@ SSTemplate;
     }
 
     /**
+     * SilverStripe 3.X problem only.
+     */
+    public function testEnsureFormMessageIsCastingCorrectly()
+    {
+        $template = <<<SSTemplate
+<:MyFormMessageTest
+    message="\$Field.Message"
+/>
+SSTemplate;
+        $expectedHTML = <<<HTML
+<div>The field "Name" is required.</div>
+HTML;
+        $formField = new TextField("Name", "Name");
+        $formField->setError("The field \"Name\" is required.", "error");
+        $resultHTML = SSViewer::fromString($template)->process(
+            new ArrayData(
+                array(
+                'Field' => $formField,
+                )
+            )
+        );
+        $this->assertEqualIgnoringWhitespace(
+            $expectedHTML,
+            $resultHTML,
+            'Unexpected output. If you got \'The field &quot;Name&quot; is required\', then this test is definitely broken.'
+        );
+    }
+
+    /**
      * Taken from "framework\tests\view\SSViewerTest.php"
      */
     protected function assertEqualIgnoringWhitespace($a, $b, $message = '')

--- a/tests/templates/components/MyFormMessageTest.ss
+++ b/tests/templates/components/MyFormMessageTest.ss
@@ -1,0 +1,3 @@
+<div>
+    $message
+</div>


### PR DESCRIPTION
fix(ComponentService): Fix bug where $Message from a FormField would be double escaped and print &quot - Github #16