### PR TITLE
fix(JSON): Fix nested json

### DIFF
--- a/src/SilbinaryWolf/Components/ComponentService.php
+++ b/src/SilbinaryWolf/Components/ComponentService.php
@@ -95,6 +95,7 @@ class ComponentService
                         }
                         foreach ($jsonData as $propertyName => $value) {
                             if (is_array($value)) {
+                                $value = self::recursivelyConvertFlatArraysToArrayList($value);
                                 $value = 'new '.ArrayList::class.'('.var_export($value, true).')';
                             }
                             $phpCodeValueParts[] = "\$_props['".$propertyName."'][] = ".$value.";";
@@ -243,5 +244,20 @@ PHP;
         // $this->extend('updateRenderComponent', $result, $name, $props, $scope);
         //
         return $result;
+    }
+
+    private static function recursivelyConvertFlatArraysToArrayList(array $array)
+    {
+        foreach ($array as $prop => &$value) {
+            if (is_array($value)) {
+                $value = self::recursivelyConvertFlatArraysToArrayList($value);
+            }
+            unset($value);
+        }
+        if (isset($array[0])) {
+            $array = new ArrayList($array);
+            //$array = 'new '.ArrayList::class.'('.var_export($array, true).')';
+        }
+        return $array;
     }
 }

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -527,6 +527,64 @@ SSTemplate;
         }
     }
 
+    public function testJSONDeeplyNested()
+    {
+        $template = <<<SSTemplate
+<:JSONNestedTest
+    _json='{
+        "SubMenu": [
+            {
+                "Title": "Subnav item number one with children",
+                "Link": "https://google.com",
+                "LinkingMode": "section",
+                "Children": [
+                    {
+                        "Title": "Tertiary item number one",
+                        "Link": "https://google.com",
+                        "LinkingMode": "link"
+                    },
+                    {
+                        "Title": "Tertiary item number two",
+                        "Link": "https://google.com",
+                        "LinkingMode": "link"
+                    },
+                    {
+                        "Title": "Tertiary item number three",
+                        "Link": "https://google.com",
+                        "LinkingMode": "link"
+                    }
+                ]
+            },
+            {
+                "Title": "Subnav item number two",
+                "Link": "https://google.com",
+                "LinkingMode": "link",
+                "Children": ""
+            },
+            {
+                "Title": "Subnav item number three",
+                "Link": "https://google.com",
+                "LinkingMode": "current",
+                "Children": ""
+            },
+            {
+                "Title": "Subnav item number four",
+                "Link": "https://google.com",
+                "LinkingMode": "link",
+                "Children": ""
+            }
+        ]
+    }'
+/>
+SSTemplate;
+        $expectedHTML = <<<HTML
+        <div></div>
+HTML;
+
+        $resultHTML = SSViewer::fromString($template)->process(null);
+        $this->assertEqualIgnoringWhitespace($expectedHTML, $resultHTML, 'Unexpected output');
+    }
+
     /**
      * Taken from "framework\tests\view\SSViewerTest.php"
      */

--- a/tests/templates/components/JSONNestedTest.ss
+++ b/tests/templates/components/JSONNestedTest.ss
@@ -1,0 +1,14 @@
+<% if $SubMenu %>
+    <% loop $SubMenu %>
+        <h2>$Title</h2>
+        <% if $Children %>
+        <ul>
+            <% loop $Children %>
+            <li>
+                <a class="$LinkingMode" href="$Link">$Title</a>
+            </li>
+            <% end_loop %>
+        </ul>
+        <% end_if %>
+    <% end_loop %>
+<% end_if %>


### PR DESCRIPTION
Related Issue: 
https://github.com/silbinarywolf/silverstripe-components/issues/28

This is currently broken on purpose. So far this just has the test case in.

**Whats left to do:**
- Update the `$expectedHTML` for `testJSONDeeplyNested` to be what the HTML output should be.
- We need to update the outputting of a SilverStripe template so that instead of using `var_export($value, true)` to get PHP code of an array with nested arrays, we simply walk the entire array structure and generate the needed PHP code.

**How to recursively walk an array structure**
```
<?php
// Iteration on leafs AND nodes
foreach (new RecursiveIteratorIterator(new RecursiveArrayIterator($candidate), RecursiveIteratorIterator::CATCH_GET_CHILD) as $key => $value) {
    echo 'My node ' . $key . ' with value ' . $value . PHP_EOL;
}
```
Source: http://php.net/manual/en/function.array-walk-recursive.php#116876