### PR TITLE
Add template logic for nested data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.2.x-dev"
         },
         "installer-name": "components"
     },

--- a/src/SilbinaryWolf/ArrayListExportable.php
+++ b/src/SilbinaryWolf/ArrayListExportable.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Used in place of ArrayList when preparing nested arrays for export for SS templates.
+ *
+ * var_export calls '__set_state' on classes, so it produces code like:
+ *
+ *      ArrayList::__set_state(array('items' => [...]))
+ *
+ * And because ArrayList doens't implement '__set_state', executing the code throws errors.
+ * So we work around this by using an ArrayListExportable to produce:
+ *
+ *      ArrayListExportable::__set_state(array('items' => [...]))
+ *
+ * And implement '__set_state' to return a constructed ArrayList.
+ */
+class ArrayListExportable
+{
+    public function __construct($array = array())
+    {
+        // need to store items for var_export to recurse
+        $this->items = $array;
+    }
+
+    public static function __set_state ($array)
+    {
+        // when executed, we naruto-style body-replace with in an ArrayList
+        return new ArrayList($array['items']);
+    }
+}

--- a/src/SilbinaryWolf/Components/ComponentService.php
+++ b/src/SilbinaryWolf/Components/ComponentService.php
@@ -261,32 +261,3 @@ PHP;
         return $result;
     }
 }
-
-/**
- * Used in place of ArrayList when preparing nested arrays for export for SS templates.
- *
- * var_export calls '__set_state' on classes, so it produces code like:
- *
- *      ArrayList::__set_state(array('items' => [...]))
- *
- * And because ArrayList doens't implement '__set_state', executing the code throws errors.
- * So we work around this by using an ArrayListExportable to produce:
- *
- *      ArrayListExportable::__set_state(array('items' => [...]))
- *
- * And implement '__set_state' to return a constructed ArrayList.
- */
-class ArrayListExportable
-{
-    public function __construct($array = array())
-    {
-        // need to store items for var_export to recurse
-        $this->items = $array;
-    }
-
-    public static function __set_state ($array)
-    {
-        // when executed, we naruto-style body-replace with in an ArrayList
-        return new ArrayList($array['items']);
-    }
-}

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -529,6 +529,113 @@ SSTemplate;
     }
 
     /**
+     * Test iterating nested arrays in templates
+     */
+    public function testJSONDeeplyNested()
+    {
+        $template = <<<SSTemplate
+<:JSONNestedTest
+    _json='{
+        "NestedData": [
+            {
+                "Title": "Item 1.1",
+                "Children": [
+                    {
+                        "Title": "Item 2.1"
+                    },
+                    {
+                        "Title": "Item 2.2"
+                    },
+                    {
+                        "Title": "item 2.3",
+                        "Children": [
+                            {
+                                "Title": "Item 3.1"
+                            },
+                            {
+                                "Title": "Item 3.2"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "Title": "Item 1.2"
+            },
+            {
+                "Title": "Item 1.3",
+                "Children": [
+                    {
+                        "Title": "Item 2.4",
+                        "Children": [
+                            {
+                                "Title": "Item 3.3"
+                            },
+                            {
+                                "Title": "Item 3.4"
+                            }
+                        ]
+                    },
+                    {
+                        "Title": "Item 2.5"
+                    },
+                    {
+                        "Title": "item 2.6"
+                    }
+                ]
+            }
+        ]
+    }'
+/>
+SSTemplate;
+        $expectedHTML = <<<HTML
+    <h2>Item 1.1</h2>
+    <ul>
+    <li>
+        <h3>Item 2.1</h3>
+    </li>
+    <li>
+        <h3>Item 2.2</h3>
+    </li>
+    <li>
+        <h3>item 2.3</h3>
+        <ul>
+            <li>
+            <h4>Item 3.1</h4>
+            </li>
+            <li>
+            <h4>Item 3.2</h4>
+            </li>
+        </ul>
+    </li>
+    </ul>
+    <h2>Item 1.2</h2>
+    <h2>Item 1.3</h2>
+    <ul>
+    <li>
+        <h3>Item 2.4</h3>
+        <ul>
+            <li>
+            <h4>Item 3.3</h4>
+            </li>
+            <li>
+            <h4>Item 3.4</h4>
+            </li>
+        </ul>
+    </li>
+    <li>
+        <h3>Item 2.5</h3>
+    </li>
+    <li>
+        <h3>item 2.6</h3>
+    </li>
+    </ul>
+HTML;
+        $resultHTML = SSViewer::fromString($template)->process(null);
+        $this->assertEqualIgnoringWhitespace($expectedHTML, $resultHTML, 'Unexpected output');
+    }
+
+    /**
      * Taken from "framework\tests\view\SSViewerTest.php"
      */
     protected function assertEqualIgnoringWhitespace($a, $b, $message = '')

--- a/tests/templates/components/JSONNestedTest.ss
+++ b/tests/templates/components/JSONNestedTest.ss
@@ -1,0 +1,23 @@
+<% if $NestedData %>
+  <% loop $NestedData %>
+    <h2>$Title</h2>
+    <% if $Children %>
+      <ul>
+      <% loop $Children %>
+        <li>
+          <h3>$Title</h3>
+          <% if $Children %>
+            <ul>
+            <% loop $Children %>
+              <li>
+                <h4>$Title</h4>
+              </li>
+            <% end_loop %>
+            </ul>
+          <% end_if %>
+        </li>
+      <% end_loop %>
+      </ul>
+    <% end_if %>
+  <% end_loop %>
+<% end_if %>


### PR DESCRIPTION
JSON data given to template components can now have nested arrays of iterable children (see the SubNavigation example from front-end-tooling). Test included.

This PR resolves:
* https://github.com/symbiote/silverstripe-components/pull/29/files
* https://github.com/symbiote/silverstripe-components/issues/28

I would suggest making a new release for this addition.

Note: This change will also need to go into master, but as the source file is different, that will need to be a separate PR.