### PR TITLE
Adds back child html functionality, add test, and fixes json strings

### DIFF
--- a/src/SilbinaryWolf/Components/ComponentService.php
+++ b/src/SilbinaryWolf/Components/ComponentService.php
@@ -63,7 +63,7 @@ class ComponentService
                     }
                 default:
                     {
-                    // restricted name error
+                        // restricted name error
                         if ($propName[0] === '_') {
                             throw new SSTemplateParseException('Invalid special property type: "' . $propName . '", properties that start with a _ are reserved for special functionality. Available special property types are: "_json".', $parser);
                             break;
@@ -73,6 +73,9 @@ class ComponentService
                     }
             }
         }
+
+        // handle child html
+        $php .= self::handleChildHTML($data, $properties, $parser);
         
         // final render call for output php
         $php .= "\$val .= Injector::inst()->get('SilbinaryWolf\\Components\\ComponentService')->renderComponent('$componentName', \$_props, \$scope);\nunset(\$_props);\n";
@@ -139,10 +142,33 @@ class ComponentService
             if (is_array($value)) {
                 $value = self::exportNestedDataForTemplates($value);
             }
+            // handle strings
+            else if (is_string($value)) {
+                $value = '"' . $value . '"';
+                var_dump($value);
+            }
             $buffer .= self::Prop2PHP($name, $value);
         }
 
         return $buffer;
+    }
+
+    private static function handleChildHTML($data, $properties, $parser)
+    {
+        if (isset($data['Children']['php'])) {
+            // handle children property collision
+            if (isset($properties['children'])) {
+                throw new SSTemplateParseException('Cannot use "children" as a property name and have inner HTML.', $parser);
+            }
+
+            // construct php
+            $value = $data['Children']['php'];
+            $php = "\$_props['children'] = '';\n" . $value;
+            $php = str_replace("\$val .=", "\$_props['children'] .=", $php);
+            $php .= "\$_props['children'] = DBField::create_field('HTMLText', \$_props['children']);\n";
+
+            return $php;
+        }
     }
 
     private static function Prop2PHP($name, $value)

--- a/src/SilbinaryWolf/Components/ComponentService.php
+++ b/src/SilbinaryWolf/Components/ComponentService.php
@@ -169,6 +169,7 @@ class ComponentService
 
             return $php;
         }
+        return '';
     }
 
     private static function Prop2PHP($name, $value)

--- a/src/SilbinaryWolf/Components/ComponentService.php
+++ b/src/SilbinaryWolf/Components/ComponentService.php
@@ -145,7 +145,6 @@ class ComponentService
             // handle strings
             else if (is_string($value)) {
                 $value = '"' . $value . '"';
-                var_dump($value);
             }
             $buffer .= self::Prop2PHP($name, $value);
         }

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -636,6 +636,41 @@ HTML;
     }
 
     /**
+     * Test iterating multiple root level properties in templates
+     */
+    public function testJSONMultiRoot()
+    {
+        $template = <<<SSTemplate
+<:JSONRootTest
+    _json='{
+        "Title": "Root Test",
+        "Root1": [
+            {"Title": "one"},
+            {"Title": "two"}
+        ],
+        "Root2": [
+            {"Title": "three"},
+            {"Title": "four"}
+        ]
+    }'
+/>
+SSTemplate;
+        $expectedHTML = <<<HTML
+    <h1>Root Test</h1>
+    <div>
+        <h2>one</h2>        
+        <h2>two</h2>
+    </div>
+    <div>
+        <h2>three</h2>
+        <h2>four</h2>        
+    </div>
+HTML;
+        $resultHTML = SSViewer::fromString($template)->process(null);
+        $this->assertEqualIgnoringWhitespace($expectedHTML, $resultHTML, 'Unexpected output');
+    }
+
+    /**
      * Taken from "framework\tests\view\SSViewerTest.php"
      */
     protected function assertEqualIgnoringWhitespace($a, $b, $message = '')

--- a/tests/templates/components/JSONRootTest.ss
+++ b/tests/templates/components/JSONRootTest.ss
@@ -1,0 +1,18 @@
+
+<% if $Title %>
+  <h1>$Title</h1>
+<% end_if %>
+<% if $Root1 %>
+  <div>
+    <% loop $Root1 %>
+      <h2>$Title</h2>
+    <% end_loop %>
+  </div>
+<% end_if %>
+<% if $Root2 %>
+  <div>
+    <% loop $Root2 %>
+      <h2>$Title</h2>
+    <% end_loop %>
+  </div>
+<% end_if %>


### PR DESCRIPTION
This is part 2 of https://github.com/symbiote/silverstripe-components/pull/33 which was merged prematurely. A 1.3 release should be created for these changes.

## Child HTML functionality
Inner html is processsed as it was (though refactored along with the rest of the class). It may be the case that inner html shouldn't be allowed, but for now at least it should be left in.

## Test
Adds test for multiple root level properties in json data.

## Json strings
Json strings were not being wrapped in quotes. PHP would identify them as undeclared constants and fallback to identifying them as a string and throw a notice. Tests throw exceptions on notice. Would eventually be an issue when a string overlapped with a constant name, etc.

