### PR TITLE
fix(DBComponentField) Swapped to using getValue

### DIFF
--- a/src/Symbiote/Components/DBComponentField.php
+++ b/src/Symbiote/Components/DBComponentField.php
@@ -58,7 +58,14 @@ class DBComponentField extends DBText
             //        continue;
             //    }
             //}
-            $value .= $field->forTemplate();
+            
+            // NOTE(Marcus) 2019-02-20
+            //
+            // Have swapped this to just concating the raw value; it seems unusual to use
+            // forTemplate on a field because the result of this is normally formatted differently
+            // to the raw data which is very undesirable if the component decides to use the
+            // data in a different manner (ie, as a textarea field content)
+            $value .= $field->getValue();
         }
         $this->value = $value;
     }


### PR DESCRIPTION
Using forTemplate causes some field types to change the underlying value when evaluating the returned data value (ie nl2br, or htmlencoding). This may be a convenient default for some things, but in a general sense causes terrible problems for things like form fields. Those areas that do need it can call the relevant things (like .ATT, .XML) from the template