### PR TITLE
fix(ComponentService): Malformed children template code

### DIFF
--- a/src/Symbiote/Components/ComponentService.php
+++ b/src/Symbiote/Components/ComponentService.php
@@ -172,6 +172,8 @@ class ComponentService
             // construct php
             $value = $data['Children']['php'];
             $php = "\$_props['children'] = '';\n" . $value;
+            $php = str_replace("\$_props = array();\n", "", $php);
+            $php = str_replace("unset(\$_props);\n", "", $php);
             $php = str_replace("\$val .=", "\$_props['children'] .=", $php);
             $php .= "\$_props['children'] = SilverStripe\ORM\FieldType\DBField::create_field('HTMLText', \$_props['children']);\n";
 


### PR DESCRIPTION
PHP template code for 'children' needed to have `_props` assignment/unset stripped so that it doesn't overwrite/unset the parent's data.